### PR TITLE
Overlay for Orange Pi Zero 3

### DIFF
--- a/dts/opizero3-sun50i-h616-st7796.dts
+++ b/dts/opizero3-sun50i-h616-st7796.dts
@@ -5,12 +5,13 @@
 MOSI      	PH7 SPI1_MOSI
 MISO      	PH8 SPI1_MISO
 CLK       	PH6 SPI1_CLK
-TFT_CS    	PH9 SPI1_CS
+TFT_CS    	PC10
 DC        	PC7 
 TOUCH_CS  	PC14
 TOUCH_IRQ 	PC15
 LED       	3.3V
 */
+
 
 / {
     compatible = "allwinner,sun50i-h616";
@@ -18,17 +19,19 @@ LED       	3.3V
     fragment@0 {
         target-path = "/soc/spi@5011000";
         __overlay__ {
-            num-cs = <2>;
+            num-cs = <3>;
 
                 cs-gpios = <&pio 2 14 0>, /* TOUCH_CS PC14 */
-                           <&pio 7 9 0>;  /* TFT_CS PH9 */
+			   <0>,           /* spidev1.1 compatibility */
+			   <&pio 2 10 0>; /* TFT_CS PC10 */
+
             status = "okay";
             #address-cells = <1>;
             #size-cells = <0>;
 
             st7796: st7796s@0{
                 compatible = "sitronix,st7796s";
-                reg = <0>;
+                reg = <2>;
                 spi-max-frequency = <25000000>;
                 fps = <30>;
                 buswidth = <8>;
@@ -47,7 +50,7 @@ LED       	3.3V
             status = "okay";
             ads7846@0 {
                 compatible = "ti,ads7846";
-                reg = <1>;
+                reg = <0>;
                 status = "okay";
                 spi-max-frequency = <1000000>;
                 interrupts = <2 15 2>; /* high-to-low edge triggered */
@@ -63,9 +66,8 @@ LED       	3.3V
                ti,y-max = /bits/ 16 <0xFFF>;
                ti,x-plate-ohms = /bits/ 16 <60>;
                ti,pressure-max = /bits/ 16 <255>;
-                ti,swap-xy = <0>;   };
-        };
-        };
-
-
+                ti,swap-xy = <0>;
+	    };
+	};
     };
+};

--- a/dts/opizero3-sun50i-h616-st7796.dts
+++ b/dts/opizero3-sun50i-h616-st7796.dts
@@ -32,7 +32,7 @@ LED       	3.3V
             st7796: st7796s@0{
                 compatible = "sitronix,st7796s";
                 reg = <2>;
-                spi-max-frequency = <25000000>;
+                spi-max-frequency = <50000000>;
                 fps = <30>;
                 buswidth = <8>;
                 dc-gpios = <&pio 2 7 0>;     /* TFT D/C PC7 */
@@ -52,7 +52,7 @@ LED       	3.3V
                 compatible = "ti,ads7846";
                 reg = <0>;
                 status = "okay";
-                spi-max-frequency = <1000000>;
+                spi-max-frequency = <125000>;
                 interrupts = <2 15 2>; /* high-to-low edge triggered */
                     interrupt-parent = <&pio>;   /* PC15 */
                 pendown-gpio = <&pio 2 15 0>;

--- a/dts/opizero3-sun50i-h616-st7796.dts
+++ b/dts/opizero3-sun50i-h616-st7796.dts
@@ -1,0 +1,71 @@
+/dts-v1/;
+/plugin/;
+
+/*
+MOSI      	PH7 SPI1_MOSI
+MISO      	PH8 SPI1_MISO
+CLK       	PH6 SPI1_CLK
+TFT_CS    	PH9 SPI1_CS
+DC        	PC7 
+TOUCH_CS  	PC14
+TOUCH_IRQ 	PC15
+LED       	3.3V
+*/
+
+/ {
+    compatible = "allwinner,sun50i-h616";
+
+    fragment@0 {
+        target-path = "/soc/spi@5011000";
+        __overlay__ {
+            num-cs = <2>;
+
+                cs-gpios = <&pio 2 14 0>, /* TOUCH_CS PC14 */
+                           <&pio 7 9 0>;  /* TFT_CS PH9 */
+            status = "okay";
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            st7796: st7796s@0{
+                compatible = "sitronix,st7796s";
+                reg = <0>;
+                spi-max-frequency = <25000000>;
+                fps = <30>;
+                buswidth = <8>;
+                dc-gpios = <&pio 2 7 0>;     /* TFT D/C PC7 */
+                rotate = <270>;
+                debug = <1>;
+            };
+        };
+    };
+
+    fragment@1 {
+        target-path = "/soc/spi@5011000";
+        __overlay__ {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            status = "okay";
+            ads7846@0 {
+                compatible = "ti,ads7846";
+                reg = <1>;
+                status = "okay";
+                spi-max-frequency = <1000000>;
+                interrupts = <2 15 2>; /* high-to-low edge triggered */
+                    interrupt-parent = <&pio>;   /* PC15 */
+                pendown-gpio = <&pio 2 15 0>;
+
+                /* driver defaults, optional */
+
+               ti,keep-vref-on = <1>;
+               ti,x-min = /bits/ 16 <00>;
+               ti,x-max = /bits/ 16 <0xFFF>;
+               ti,y-min = /bits/ 16 <00>;
+               ti,y-max = /bits/ 16 <0xFFF>;
+               ti,x-plate-ohms = /bits/ 16 <60>;
+               ti,pressure-max = /bits/ 16 <255>;
+                ti,swap-xy = <0>;   };
+        };
+        };
+
+
+    };


### PR DESCRIPTION
Added .dts for Orange Pi Zero 3. Tested on Debian Bookworm 6.1.31 official image from orangepi.org.
This overlay does not use SPI1 CS1 (PH9), so you can use it with default spi1_cs1_spidev overlay simultaneously.